### PR TITLE
Error & TODO & DONE

### DIFF
--- a/src/pages/community-create/community-create.html
+++ b/src/pages/community-create/community-create.html
@@ -30,10 +30,14 @@
 
     <ion-row>
       <ion-col col-12>
-        <ion-input class="cc-title" placeholder="제목 입력" [(ngModel)]="title"></ion-input>
+        <ion-item class="item-left">
+          <ion-input class="cc-title" placeholder="제목 입력" [(ngModel)]="title"></ion-input>
+        </ion-item>
       </ion-col>
       <ion-col col-12>
-        <ion-textarea elastic class="cc-textarea" placeholder="내용 입력" [(ngModel)]="text"></ion-textarea>
+        <ion-item class="item-left">
+          <ion-textarea elastic class="cc-textarea" placeholder="내용 입력" [(ngModel)]="text"></ion-textarea>
+        </ion-item>
       </ion-col>
     </ion-row>
     <ion-row class="cc-photo">

--- a/src/pages/community-create/community-create.scss
+++ b/src/pages/community-create/community-create.scss
@@ -12,6 +12,9 @@ page-community-create {
     .checkbox-md, .checkbox-ios {
         margin:2vw 4vw 2vw 4vw !important;
     }
+    .item-left {
+        padding : 0;
+    }
     .item-inner {
         border-bottom:none !important;
     }

--- a/src/pages/community-create/community-create.ts
+++ b/src/pages/community-create/community-create.ts
@@ -28,27 +28,6 @@ export class CommunityCreatePage {
     public afDB: AngularFireDatabase, public dataProvider: DataProvider) {
     
     this.user = firebase.auth().currentUser;
-   
-    // 기존 리스트를 불러와서 푸시하는 방식
-    
-
-
-    // if (this.communityName.substring(0, 4) == "INFO") {
-    //   this.afDB.list('/category/0/category_inner', ref => ref).valueChanges().subscribe(Items => {
-    //     this.specificDB = Items;
-    //     console.log(this.specificDB)
-    //   });
-    // }
-    // else if (this.communityName.substring(0, 4) == "LIFE") {
-    //   this.afDB.list('/category/1/category_inner', ref => ref).valueChanges().subscribe(Items => {
-    //     this.specificDB = Items;
-    //   });
-    // }
-    // else if (this.communityName.substring(0, 4) == "TRAV") {
-    //   this.afDB.list('/category/2/category_inner', ref => ref).valueChanges().subscribe(Items => {
-    //     this.specificDB = Items;
-    //   });
-    // }
   }
 
   ionViewDidLoad() {
@@ -62,24 +41,7 @@ export class CommunityCreatePage {
 
   
   addCommunity(title: string, text: string) {
-    // 기존 리스트를 불러와서 푸시하는 방식
-    // this.communityRef.push({
-    //   title: title,
-    //   description: text,
-    //   type: this.specificName,
-    //   writer: firebase.auth().currentUser.uid,
-    //   date: firebase.database['ServerValue'].TIMESTAMP,
-    //   like: 0,
-    //   view : 0,
-    // }).then((success) => {
-    //   if (this.imageUpload.images.length > 0) {
-
-    //     this.imageUpload.key = success.key;
-    //     this.imageUpload.uploadImages("community/" + this.communityName);
-    //   }
-    //   this.viewCtrl.dismiss({ data: true });
-    //   this.addAddtions();
-    // })
+    text = text.replace(/\n/g, '<br>');
 
     // 경로만 불러와서 푸시하는 방식------------------------------
     this.communityRef.push({
@@ -133,7 +95,8 @@ export class CommunityCreatePage {
     console.log(this.selectedSpecific);
   }
   checkTrim() {
-    if ((this.text.trim() == "") || (this.text.trim() == null) || (this.title.trim() == null) || (this.title.trim() == "") || this.selectedSpecific == null) return true;
+    if ((this.title.trim() == null) || (this.title.trim() == "") || this.selectedSpecific == null ||
+    ((this.imageUpload.images.length == 0) && (this.text.trim() == "") || (this.text.trim() == null))) return true;
 
     else return false;
 

--- a/src/pages/community-detail/community-detail.html
+++ b/src/pages/community-detail/community-detail.html
@@ -23,8 +23,8 @@
         <br>
         <span class="cd-nickname">{{bullet.writer}}</span> |
         <span class="cd-like-cnt">{{bullet.like}}</span> |
-        <span class="cd-comment-cnt">{{bullet.title}}</span> |
-        <span class="cd-time">{{bullet.date}}</span>
+        <span class="cd-comment-cnt">{{bullet.commentCount}}</span> |
+        <span class="cd-time">{{bullet.date | DateFormat}}</span>
       </ion-col>
     </ion-row>
     <!-- 게시글 상단 프로필 끝-->
@@ -42,8 +42,8 @@
     <!-- 게시글 사용자 작성 내용 시작-->
     <ion-row class="cd-row-text" (click)="presentDetailModal()">
       <ion-col col-12>
-        <span class="cd-text"></span>
-        <br> {{bullet.description}}
+        <!-- <span class="cd-text"></span> -->
+        <div class="cd-text" [innerHTML]="bullet.description"></div>
         <span class="cd-text-translated"></span>
       </ion-col>
     </ion-row>
@@ -98,7 +98,7 @@
         <ion-row class="cd-row-cmt-profile">
           <ion-col col-12>
             <span class="cd-nickname">{{comment.writer}} | </span>
-            <span class="cd-time">{{comment.date}}</span>
+            <span class="cd-time">{{comment.date | DateFormat}}</span>
             <br>
             <span class="cd-title">{{comment.description}}</span>
           </ion-col>

--- a/src/pages/community-detail/community-detail.module.ts
+++ b/src/pages/community-detail/community-detail.module.ts
@@ -3,6 +3,7 @@ import { IonicPageModule } from 'ionic-angular';
 import { TranslateModule } from '@ngx-translate/core';
 import { CommunityDetailPage } from './community-detail';
 import { IonicImageViewerModule } from 'ionic-img-viewer';
+import { PipeModule } from '../../pipes/pipe.module';
 
 
 
@@ -15,7 +16,8 @@ import { IonicImageViewerModule } from 'ionic-img-viewer';
   imports: [
     IonicPageModule.forChild(CommunityDetailPage),
     TranslateModule.forChild(),
-    IonicImageViewerModule
+    IonicImageViewerModule,
+    PipeModule
   ],
   exports: [
     CommunityDetailPage

--- a/src/pages/community-detail/community-detail.ts
+++ b/src/pages/community-detail/community-detail.ts
@@ -60,7 +60,6 @@ export class CommunityDetailPage {
 
   ionViewDidLoad() {
     console.log('ionViewDidLoad CommunityDetailPage');
-    // 트랜잭션으로 변경 필요
     firebase.database().ref(this.bulletDBName).child('view').transaction(function(currentView){
       return currentView+1;
     });

--- a/src/pages/community-template/community-template.html
+++ b/src/pages/community-template/community-template.html
@@ -7,6 +7,7 @@
     </ion-buttons>
     <ion-title color="top-text" *ngIf="searchBarFlag == 0">{{categoryName | translate}}</ion-title>
     <ion-input class="top-search" *ngIf="searchBarFlag == 1" placeholder="검색하십쇼." [(ngModel)]="searchText"></ion-input>
+    <!-- <ion-searchbar (ionInput)="getItems($event)" *ngIf="searchBarFlag == 1" placeholder="검색하십쇼."></ion-searchbar> -->
     <ion-buttons end>
       <button ion-button icon-only (click)="openSearchBar()">
         <ion-icon name="flaticon-search" color="x-white"></ion-icon>
@@ -103,7 +104,6 @@
               </ion-col>
               <ion-col col-3 text-center><span class="cb-nickname">{{bullet.payload.val().writer}}</span></ion-col>
               <ion-col col-2 text-center><span class="cb-time">{{bullet.payload.val().date | DateFormat}}</span></ion-col>
-              <!--dateformat 넣어주셈! -->
               </ion-row>
           </ion-grid>
      </ion-list>
@@ -118,12 +118,24 @@
               </ion-col>
               <ion-col col-3 text-center><span class="cb-nickname">{{bullet.payload.val().writer}}</span></ion-col>
               <ion-col col-2 text-center><span class="cb-time">{{bullet.payload.val().date | DateFormat}}</span></ion-col>
-              <!--dateformat 넣어주셈! -->
               </ion-row>
           </ion-grid>
      </ion-list>
      </div>
   </div>
+
+  <!-- css 작업 필요 및 기능부 구현 아직 안됨 -->
+  <ion-grid no-padding class="cb-paging">
+      <ion-row class="cb-paging-row">
+        <ion-col col-1 text-center><ion-icon name="flaticon-left-arrow"></ion-icon></ion-col>  
+        <ion-col col-2 text-center (click)="pageTest()">1</ion-col>
+        <ion-col col-2 text-center (click)="pageTest()">2</ion-col>
+        <ion-col col-2 text-center (click)="pageTest()">3</ion-col>
+        <ion-col col-2 text-center (click)="pageTest()">4</ion-col>
+        <ion-col col-2 text-center (click)="pageTest()">5</ion-col>
+        <ion-col col-1 text-center><ion-icon name="flaticon-right-arrow"></ion-icon></ion-col>  
+      </ion-row>
+    </ion-grid>
 
   
   <ion-fab right bottom>

--- a/src/pages/community-template/community-template.scss
+++ b/src/pages/community-template/community-template.scss
@@ -12,7 +12,7 @@ page-community-template {
     .text-ios {
         color:map-get($colors,x-gray-middle) !important;
     }
-
+    
     .ct-grid-best {
         margin-bottom:4vw;
     }
@@ -38,6 +38,10 @@ page-community-template {
     .ct-comment {
         font-size:3vw;
         color:map-get($colors,x-pink);
+    }
+    .cb-paging {
+        font-size:4vw;
+        color:map-get($colors,x-gray-middle);
     }
 
     ion-row{

--- a/src/pages/community-template/community-template.ts
+++ b/src/pages/community-template/community-template.ts
@@ -55,6 +55,14 @@ export class CommunityTemplatePage {
     this.navCtrl.pop();
   }
 
+  pageTest() {
+    // firebase 쿼리 페이지화
+  }
+
+  // getItems(searchbar) {
+
+  // }
+
   openSearchBar() {
     if (this.searchBarFlag == 0) {
       // 서치바 닫혀있는 상태면 서치바 열기


### PR DESCRIPTION
커뮤니티 - 
0.TODO 댓글 안 보임. 추가적으로 댓글이 아무것도 없을 때, "첫 댓글을 남겨주세요" 부분 디자인 필요.
1.ERROR 제목이 2줄 이상으로 넘어가면, 커뮤니티 보드에서 영역을 넘어서서 표현됨.
2.TODO 게시글 페이지 번호가 안보임. 즉, 게시글수가 5개까지만 보임. => https://firebase.google.com/docs/firestore/query-data/query-cursors?hl=ko
3.ERROR 게시글 작성시, 많은 내용을 입력해도 작성버튼의 위치는 고정되어있음. 따라서 ui도 이상해지고 버튼이 textarea를 가리는 일 발생. 추가적으로 키보드도 textarea 가림.

기타 -
1.ERROR 사이드탭에서 들어갈 수 있는 모든 모달에서, 취소버튼으로 back 할 경우 2번 눌러야 가능함.
	- 정확한 시나리오는 모르겠으나 3번눌러야 될 때도 있음.
2.ERROR 가끔 social의 스크롤 기능이 병신됨. (현재상황에서 중요한건 아닌듯.)


**DONE by HS
1.ERROR comuunity-detail.html 에서 <span class="cd-comment-cnt">{{bullet.title}} 를 <span class="cd-comment-cnt">{{bullet.commentCount}}로 바꿈
2.TODO 글 작성에서 내용없이 이미지만 올려도 글 작성이 가능함.
3.ERROR 글 작성시에 앞서 작성한 글 수정 불가. 그러려면 이제 까지 썼던 모든 부분을 다 지워서 그쪽으로 넘어가야함. =>input이나 textarea는 ion-item 안에 들어가야합니다.
4.ERROR 내용 작성에서 개행이 되지만, 실제 작성된 내용을 살펴보면 개행처리가 안되있음. => 서버 올리기 전에 \n을 <br>로 바꿈. 가져올때는 [innerHTML]로 가져옴.
5.TODO community-detail 에 DateFormat 넣음**

* 기존의 TODO와 중복될 수도 있으며, ERROR 판단 기준은 코드 및 UI상 치명적이라고 생각되는 부분입니다.